### PR TITLE
Enhanced MIME and UTI document definition

### DIFF
--- a/QuickLookAPK/QuickLookAPK-Info.plist
+++ b/QuickLookAPK/QuickLookAPK-Info.plist
@@ -7,6 +7,10 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>application/vnd.android.package-archive</string>
+			</array>
 			<key>CFBundleTypeRole</key>
 			<string>QLGenerator</string>
 			<key>LSItemContentTypes</key>

--- a/QuickLookAPK/QuickLookAPK-Info.plist
+++ b/QuickLookAPK/QuickLookAPK-Info.plist
@@ -12,6 +12,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.android.package-archive</string>
+				<string>public.archive.apk</string>
 			</array>
 		</dict>
 	</array>

--- a/QuickLookAPK/QuickLookAPK-Info.plist
+++ b/QuickLookAPK/QuickLookAPK-Info.plist
@@ -11,7 +11,6 @@
 			<string>QLGenerator</string>
 			<key>LSItemContentTypes</key>
 			<array>
-				<string>dyn.ah62d4rv4ge80c6dp</string>
 				<string>com.android.package-archive</string>
 			</array>
 		</dict>


### PR DESCRIPTION
I've received some feedback that Keka breaks this plugin: https://github.com/aonez/Keka/issues/276

So looking at the document definition, I think this will help the plugin:

- Removed dynamically generated UTI (added on https://github.com/hezi/QuickLookAPK/pull/4)
- Added public UTI alternative
- Added MIME type

I'm also adding the private UTI in Keka. I can't really find the public (used in Keka) or the private (used in this plugin) UTIs anywhere, so adding the MIME type might be handy.