### PR TITLE
Support dark mode

### DIFF
--- a/QuickLookAPK/HZAndroidPackage.m
+++ b/QuickLookAPK/HZAndroidPackage.m
@@ -183,7 +183,10 @@ NSString *androidPackageHTMLPreview(HZAndroidPackage *package)
 {
     NSMutableString *stringBuilder = [NSMutableString string];
 
-    [stringBuilder appendString:@"<html><body style='font-family:sans-serif'><h1>"];
+    [stringBuilder appendString:@"<!doctype html>"];
+    [stringBuilder appendString:@"<html>"];
+    [stringBuilder appendString:@"<head><meta charset='utf-8'><style>body {background: #fff; color: #000; font-family: system-ui, sans-serif;} @media (prefers-color-scheme: dark) { body {background: #323232; color: #fff;} }</style></head>"];
+    [stringBuilder appendString:@"<body><h1>"];
     
     if(package.iconData.length != 0)
     {


### PR DESCRIPTION
Requires macOS 10.14.4

Also:
- Add a doctype and UTF-8 charset
- Change font to system-ui, sans-serif

<img width="918" alt="Screenshot" src="https://user-images.githubusercontent.com/6135313/55014560-23233500-5026-11e9-9995-b5ba34fabf48.png">
