### PR TITLE
Fix package info extracted as null

### DIFF
--- a/QuickLookAPK/HZAndroidPackage.m
+++ b/QuickLookAPK/HZAndroidPackage.m
@@ -266,7 +266,7 @@ NSString *androidPackageHTMLPreview(HZAndroidPackage *package)
                                                 encoding:NSUTF8StringEncoding];
 
     NSError *error = nil;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"package: name='(.+)' versionCode='(.+)' versionName='(.+)' platformBuildVersionName='.*'"
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"package: name='(.+)' versionCode='(.+)' versionName='([^']+)'"
                                                                            options:NSRegularExpressionCaseInsensitive
                                                                              error:&error];
 


### PR DESCRIPTION
Update regex to fix mismatch of apks without platformBuildVersionName in manifest

Fix for #6 